### PR TITLE
adds an icon for norg files

### DIFF
--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -44,6 +44,8 @@ function Buffer:get_props()
       dev, _ = require('nvim-web-devicons').get_icon('git')
     elseif self.filetype == 'vimwiki' then
       dev, _ = require('nvim-web-devicons').get_icon('markdown')
+    elseif self.filetype == 'norg' then
+      dev, _ = require('nvim-web-devicons').get_icon('org')
     elseif self.buftype == 'terminal' then
       dev, _ = require('nvim-web-devicons').get_icon('zsh')
     elseif vim.fn.isdirectory(self.file) == 1 then


### PR DESCRIPTION
I'm only going to apply this to my own fork as I was thinking that maybe neorg's own icon could be submitted to one of the dev forks instead of relying on the Emacs `org` icon theme. For now I'll live with this.